### PR TITLE
Update apache.txt

### DIFF
--- a/install_and_setup/apache.txt
+++ b/install_and_setup/apache.txt
@@ -127,9 +127,13 @@ Below is a simple Rewrite Rule which will respond to the client with a 404 Not F
 
     RewriteMap IP txt:/etc/apache2/whitelist
     Define PoshC2 10.0.0.1 
-    RewriteCond ${IP:%{REMOTE_ADDR}|NOT-FOUND} !NOT-FOUND
+    RewriteCond ${IP:%{REMOTE_ADDR}} - [NC,OR]
+    RewriteCond ${IP:%{HTTP:X-Forwarded-For}} - [NC]
     RewriteRule ^/images/static/content/(.*) https://${PoshC2}/images/static/content/$1 [NC,P,L]    
+    # other RewriteRules here....
+    RewriteRule ^ - [R=404]
     ...
+    
 
 You have to do this for each rewrite rule you want to apply for each URL. In this case we are applying to the **/images/static/content/** path. 
 


### PR DESCRIPTION
So this change makes the whitelist check a positive  instead of a negative.   Basic logic here: if the REMOTE_ADD or the X-Forwarded-For address match the whitelist, then continue with the content checking Rewrite rules to match the content of the c2 URIs.   If both checks fail then it 404s the request.

I'm also going to add the whitelist for the content list as well to make it easy to switch out the list of URIs, and probably make it easy to proxy multiple engagements at the same time.